### PR TITLE
Adapt mocks to new API

### DIFF
--- a/R/mock_clinical_timelines.R
+++ b/R/mock_clinical_timelines.R
@@ -13,7 +13,7 @@ mock_clinical_timelines_UI <- function(id = NULL) { # nolint
     shiny::tags$h1("BI Clinical Timelines", class = "mod-title"),
     mod_clinical_timelines_UI(
       ns("clin_tl"),
-      list("serious_ae", "soc", "pref_term", "drug_rel_ae")
+      list("serious_ae_var", "soc_var", "pref_term_var", "drug_rel_ae_var")
     )
   )
 
@@ -84,7 +84,7 @@ mock_clinical_timelines_server <- function(input, output, session) {
         soc_var = "AESOC",
         serious_ae_var = "AESER",
         pref_term_var = "AEDECOD",
-        drug_rel__var = "AEREL"
+        drug_rel_ae_var = "AEREL"
       )
     ),
     ms = 50

--- a/R/mock_local_filter.R
+++ b/R/mock_local_filter.R
@@ -9,7 +9,7 @@ mock_local_filter_UI <- function(request) { # nolint
     shiny::bookmarkButton(),
     mod_local_filter_UI(
       "filter",
-      list("soc", "pref_term", "drug_rel_ae", "serious_ae")
+      list("soc_var", "pref_term_var", "drug_rel_ae_var", "serious_ae_var")
     ),
     shiny::tableOutput("table")
   )
@@ -69,7 +69,8 @@ mock_local_filter_server <- function(input, output, session) {
   filtered_data <- mod_local_filter_server(
     "filter",
     filter = list(ae_filter = list(
-      dataset_name = "adae", soc = "AESOC", pref_term = "AEDECOD", drug_rel_ae = "AEREL", serious_ae = "AESER"
+      dataset_name = "adae", soc_var = "AESOC", pref_term_var = "AEDECOD", drug_rel_ae_var = "AEREL",
+      serious_ae_var = "AESER"
     )),
     joined_data = initial_data,
     changed = shiny::reactive(1)


### PR DESCRIPTION
Minor oversight, but given that `mock_clinical_timelines_app` is exported, I thought I'd PR it now.