### PR TITLE
Update shared code snippets

### DIFF
--- a/inst/validation/specs.R
+++ b/inst/validation/specs.R
@@ -50,5 +50,6 @@ specs <- specs_list(
   sidebar_specs = sidebar_specs,
   default_values = default_values,
   integration_specs = integration_specs,
-  app_creation_specs = app_creation_specs
+  app_creation_specs = app_creation_specs,
+  jumping_feature = "Jump-to-subject feature."
 )

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -12,6 +12,7 @@ vdoc <- local({
 specs <- vdoc[["specs"]]
 #  validation (F)
 
+# YT#VH0bf15c0db690dfd3fac713f3c9b61f66#VH00000000000000000000000000000000#
 
 #' Test harness for communication with `dv.papo`.
 #'
@@ -19,13 +20,15 @@ specs <- vdoc[["specs"]]
 #' @param data Data matching the previous parameterization.
 #' @param trigger_input_id Fully namespaced input ID that, when set to a subject ID value,
 #'                         should make the module send `dv.papo` a message.
-test_communication_with_papo <- function(mod, data, trigger_input_id) {
+test_communication_with_papo <- function(mod, data, trigger_input_id, papo_spec_id, papo_spec_text) {
   datasets <- shiny::reactive(data)
 
   afmm <- list(
+    data = list(DS = data),
     unfiltered_dataset = datasets,
     filtered_dataset = datasets,
     module_output = function() list(),
+    module_names = list(papo = "Papo"),
     utils = list(switch2mod = function(id) NULL),
     dataset_metadata = list(name = shiny::reactive("dummy_dataset_name"))
   )
@@ -49,7 +52,8 @@ test_communication_with_papo <- function(mod, data, trigger_input_id) {
 
   app <- shiny::shinyApp(ui = app_ui, server = app_server)
 
-  test_that("module adheres to send_subject_id_to_papo protocol", {
+  testthat::test_that("module adheres to send_subject_id_to_papo protocol" |>
+    vdoc[["add_spec"]](papo_spec_text, papo_spec_id), { 
     app <- shinytest2::AppDriver$new(app, name = "test_send_subject_id_to_papo_protocol")
 
     app$wait_for_idle()

--- a/tests/testthat/test-message_papo.R
+++ b/tests/testthat/test-message_papo.R
@@ -37,4 +37,4 @@ mod <- mod_clinical_timelines(
 )
 data <- dv.clinlines:::prep_dummy_data()
 trigger_input_id <- "mod-main_view-debug_select_subject"
-test_communication_with_papo(mod, data, trigger_input_id)
+test_communication_with_papo(mod, data, trigger_input_id, 'jumping_feature', specs$jumping_feature)

--- a/tests/testthat/test-message_papo.R
+++ b/tests/testthat/test-message_papo.R
@@ -37,4 +37,4 @@ mod <- mod_clinical_timelines(
 )
 data <- dv.clinlines:::prep_dummy_data()
 trigger_input_id <- "mod-main_view-debug_select_subject"
-test_communication_with_papo(mod, data, trigger_input_id, 'jumping_feature', specs$jumping_feature)
+test_communication_with_papo(mod, data, trigger_input_id, "jumping_feature", specs$jumping_feature)


### PR DESCRIPTION
This PR updates the shared code snippets on this repo to the latest version available:
- The "test communication with papo" snippet (`tests/testthat/test_message_pap.R`) now defines a validation identifier for the test. That is provided from `tests/testthat/setup.R`