### PR TITLE
Bump ggplot2 dependency version.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dv.clinlines
 Title: DaVinci's Clinical Timelines
-Version: 1.1.1
+Version: 1.1.1-9000
 Authors@R:
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
@@ -22,7 +22,7 @@ Imports:
     checkmate (>= 2.3.1),
     dplyr (>= 1.1.0),
     dv.manager (>= 2.1.4),
-    ggplot2 (>= 3.4.4),
+    ggplot2 (>= 3.5.0),
     lubridate (>= 1.9.3),
     magrittr (>= 2.0.3),
     purrr (>= 1.0.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.clinlines 1.1.1-9000
+
+* Increase ggplot2 dependency version to 3.5.0 to rely on "new" guide system.
+
 # dv.clinlines 1.1.1
 
 * Some minor maintenance updates and renaming of mock app.


### PR DESCRIPTION
Now that ggplot2 4.0.0 has been published and that we use >= 3.5.0 internally, we can stop supporting the older behavior of guides.

# Hotfix checklist

- [x] Bumped minor version number on both DESCRIPTION and NEWS.md

- [x] Build passes pipeline checks

- [x] The new changes do not affect the API

- [x] The new changes do not affect the documentation (including screenshots)

- [x] The new changes do not impact the QC report